### PR TITLE
Changes the AP properties on Actor type to be Uris

### DIFF
--- a/src/KristofferStrube.ActivityStreams/ActorTypes/Actor.cs
+++ b/src/KristofferStrube.ActivityStreams/ActorTypes/Actor.cs
@@ -15,7 +15,7 @@ public class Actor : Object
     /// <remarks>This is only available as a part of ActivityPub.</remarks>
     [JsonPropertyName("outbox")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
-    public ILink? Outbox { get; set; }
+    public Uri Outbox { get; set; }
 
     /// <summary>
     /// The inbox stream contains all activities received by the actor. The server SHOULD filter content according to the requester's permission. In general, the owner of an inbox is likely to be able to access all of their inbox contents. Depending on access control, some other content may be public, whereas other content may require authentication for non-owner users, if they can access the inbox at all.
@@ -23,7 +23,7 @@ public class Actor : Object
     /// <remarks>This is only available as a part of ActivityPub.</remarks>
     [JsonPropertyName("inbox")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
-    public ILink? Inbox { get; set; }
+    public Uri Inbox { get; set; }
 
     /// <summary>
     /// This is a list of everyone who has sent a Follow activity for the actor, added as a side effect. This is where one would find a list of all the actors that are following the actor. The followers collection MUST be either an OrderedCollection or a Collection and MAY be filtered on privileges of an authenticated user or as appropriate when no authentication is given.
@@ -31,7 +31,7 @@ public class Actor : Object
     /// <remarks>This is only available as a part of ActivityPub.</remarks>
     [JsonPropertyName("followers")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
-    public ILink? Followers { get; set; }
+    public Uri Followers { get; set; }
 
     /// <summary>
     /// This is a list of everybody that the actor has followed, added as a side effect. The following collection MUST be either an OrderedCollection or a Collection and MAY be filtered on privileges of an authenticated user or as appropriate when no authentication is given.
@@ -39,7 +39,7 @@ public class Actor : Object
     /// <remarks>This is only available as a part of ActivityPub.</remarks>
     [JsonPropertyName("following")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
-    public ILink? Following { get; set; }
+    public Uri Following { get; set; }
 
     /// <summary>
     /// This is a list of every object from all of the actor's Like activities, added as a side effect. The liked collection MUST be either an OrderedCollection or a Collection and MAY be filtered on privileges of an authenticated user or as appropriate when no authentication is given.
@@ -47,7 +47,7 @@ public class Actor : Object
     /// <remarks>This is only available as a part of ActivityPub.</remarks>
     [JsonPropertyName("liked")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
-    public ILink? Liked { get; set; }
+    public Uri Liked { get; set; }
 
     /// <summary>
     /// A short username which may be used to refer to the actor, with no uniqueness guarantees.

--- a/tests/KristofferStrube.ActivityStreams.Tests/ActivityPubIntegrationTests.cs
+++ b/tests/KristofferStrube.ActivityStreams.Tests/ActivityPubIntegrationTests.cs
@@ -69,11 +69,11 @@ public class ActivityPubIntegrationTests
 
         // Assert
         ex9.Should().BeAssignableTo<Person>();
-        ex9.As<Person>().Following.Href.Should().Be("https://kenzoishii.example.com/following.json");
-        ex9.As<Person>().Followers.Href.Should().Be("https://kenzoishii.example.com/followers.json");
-        ex9.As<Person>().Liked.Href.Should().Be("https://kenzoishii.example.com/liked.json");
-        ex9.As<Person>().Inbox.Href.Should().Be("https://kenzoishii.example.com/inbox.json");
-        ex9.As<Person>().Outbox.Href.Should().Be("https://kenzoishii.example.com/feed.json");
+        ex9.As<Person>().Following.ToString().Should().Be("https://kenzoishii.example.com/following.json");
+        ex9.As<Person>().Followers.ToString().Should().Be("https://kenzoishii.example.com/followers.json");
+        ex9.As<Person>().Liked.ToString().Should().Be("https://kenzoishii.example.com/liked.json");
+        ex9.As<Person>().Inbox.ToString().Should().Be("https://kenzoishii.example.com/inbox.json");
+        ex9.As<Person>().Outbox.ToString().Should().Be("https://kenzoishii.example.com/feed.json");
         ex9.As<Person>().PreferredUsername.Should().Be("kenzoishii");
         ex9.As<Person>().Name.First().Should().Be("石井健蔵");
         ex9.As<Person>().Summary.First().Should().Be("この方はただの例です");
@@ -146,7 +146,7 @@ public class ActivityPubIntegrationTests
             JsonLDContext = new List<ReferenceTermDefinition>() { new(new("https://www.w3.org/ns/activitystreams")) },
             Id = $"https://kristoffer-strube/API/ActivityPub/Users/Bot",
             PreferredUsername = "Bot",
-            Inbox = new Link() { Href = new Uri($"https://kristoffer-strube.dk/API/ActivityPub/Users/Bot/inbox") },
+            Inbox = new Uri($"https://kristoffer-strube.dk/API/ActivityPub/Users/Bot/inbox") ,
             Type = ["Person"],
             ExtensionData = new()
             {
@@ -167,7 +167,7 @@ public class ActivityPubIntegrationTests
         // Assert
         payload.Should().BeAssignableTo<Person>();
         payload.As<Person>().PreferredUsername.Should().Be("Bot");
-        payload.As<Person>().Inbox.Href.Should().Be("https://kristoffer-strube.dk/API/ActivityPub/Users/Bot/inbox");
+        payload.As<Person>().Inbox.ToString().Should().Be("https://kristoffer-strube.dk/API/ActivityPub/Users/Bot/inbox");
         payload.As<Person>().ExtensionData["publicKey"].Deserialize<Dictionary<string, string>>().Keys.Should().HaveCount(3);
         payload.As<Person>().ExtensionData["publicKey"].Deserialize<Dictionary<string, string>>()["id"].Should().Be($"https://kristoffer-strube/API/ActivityPub/Users/Bot#main-key");
         payload.As<Person>().ExtensionData["publicKey"].Deserialize<Dictionary<string, string>>()["owner"].Should().Be($"https://kristoffer-strube/API/ActivityPub/Users/Bot");


### PR DESCRIPTION
The ActivityPub spec on W3C is great and all, but it has some real issues with specificity. It _says_ the AP properties are links, although in one case, Inbox, it calls it a 'reference'. So I get why I see a bunch of implementations that make it a Link. But when you actually try and integrate with other systems, they all assume `inbox`, `outbox`, `following`, `followers`, and `liked` are just strings containing a url. Mastodon, for example, cannot parse a profile if these properties come as Link types. Fedify-based services also won't parse a profile unless these properties are url strings.